### PR TITLE
Session naming (Issue #4)

### DIFF
--- a/Shared/Menus.swift
+++ b/Shared/Menus.swift
@@ -54,6 +54,7 @@ struct DebugMenu: View {
         Button("Wipe UserDefaults, Keeping MetaWears") { wipeDefaults(preserveMetaWearData: true) }
         Button("Wipe All UserDefaults") { wipeDefaults(preserveMetaWearData: false) }
         Button("Reset Onboarding State") { wipeOnboarding() }
+        Button("Wipe iCloud Session Data") { wipeCloudSessionData() }
     }
 }
 #endif

--- a/Shared/Model/Formatters.swift
+++ b/Shared/Model/Formatters.swift
@@ -9,6 +9,12 @@ let shortDateTimeFormatter: DateFormatter = {
     return date
 }()
 
+let descendingMetaBase4DateTimeFormatter: DateFormatter = {
+    let date = DateFormatter()
+    date.dateFormat = "yyyy-MM-dd'T'HH.mm.ss.SSS"
+    return date
+}()
+
 let mediumDateFormatter: DateFormatter = {
     let date = DateFormatter()
     date.dateStyle = idiom == .iPhone ? .short : .medium
@@ -40,5 +46,12 @@ extension DateComponentsFormatter {
         formatter.unitsStyle = .short
         formatter.zeroFormattingBehavior = .dropAll
         return formatter
+    }
+}
+
+
+extension Date {
+    func filenameFormat() -> String {
+        descendingMetaBase4DateTimeFormatter.string(from: self)
     }
 }

--- a/Shared/Model/Session.swift
+++ b/Shared/Model/Session.swift
@@ -49,33 +49,35 @@ public struct File: Identifiable {
     public var id: UUID
     public var csv: Data
     public var name: String
+    public var mac: MACAddress
 
-    public init(id: UUID, csv: Data, name: String) {
+    public init(id: UUID, csv: Data, name: String, mac: MACAddress) {
         self.id = id
         self.csv = csv
         self.name = name
+        self.mac = mac
     }
 
     public init(id: UUID = .init(),
                 csv: Data,
                 deviceName: String,
                 signal: MWNamedSignal,
-                date: Date
+                date: Date,
+                mac: MACAddress
     ) {
         self.id = id
         self.csv = csv
-        self.name = [deviceName, signal.name, date.filenameFormat()].joined(separator: " ")
+        self.name = [mac.filenameFormat(), deviceName, signal.name, date.filenameFormat()].joined(separator: "_")
         self.mac = mac
     }
 
     func duplicate() -> Self {
-        Self.init(id: .init(), csv: csv, name: name)
+        Self.init(id: .init(), csv: csv, name: name, mac: mac)
+    }
+}
 
-extension Date {
+extension MACAddress {
     func filenameFormat() -> String {
-        shortDateTimeFormatter.string(from: self)
-            .components(separatedBy: .alphanumerics.inverted)
-            .joined(separator: "-")
-            .replacingOccurrences(of: "--", with: " ")
+        self.replacingOccurrences(of: ":", with: "").uppercased()
     }
 }

--- a/Shared/Model/Session.swift
+++ b/Shared/Model/Session.swift
@@ -14,6 +14,7 @@ public struct Session: Identifiable, Hashable {
     /// Did the download complete
     public var didComplete: Bool
 
+    static let defaultName = "Session"
 
     public func duplicate(files: [File]) -> (session: Self, files: [File]) {
         let files = files.map { $0.duplicate() }

--- a/Shared/Model/Session.swift
+++ b/Shared/Model/Session.swift
@@ -64,15 +64,18 @@ public struct File: Identifiable {
     ) {
         self.id = id
         self.csv = csv
-
-        let date = shortDateTimeFormatter.string(from: date)
-            .components(separatedBy: .alphanumerics.inverted)
-            .joined(separator: "-")
-
-        self.name = [deviceName, signal.name, date].joined(separator: " ")
+        self.name = [deviceName, signal.name, date.filenameFormat()].joined(separator: " ")
+        self.mac = mac
     }
 
     func duplicate() -> Self {
         Self.init(id: .init(), csv: csv, name: name)
+
+extension Date {
+    func filenameFormat() -> String {
+        shortDateTimeFormatter.string(from: self)
+            .components(separatedBy: .alphanumerics.inverted)
+            .joined(separator: "-")
+            .replacingOccurrences(of: "--", with: " ")
     }
 }

--- a/Shared/Persistence/CoreData/CoreDataController.swift
+++ b/Shared/Persistence/CoreData/CoreDataController.swift
@@ -51,7 +51,13 @@ public class CloudKitCoreDataController: CoreDataBackgroundController {
         container = {
             let cloud = NSPersistentCloudKitContainer(name: "Sessions")
             let description = cloud.persistentStoreDescriptions.first
-            description?.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+
+            [NSMigratePersistentStoresAutomaticallyOption,
+             NSInferMappingModelAutomaticallyOption,
+             NSPersistentStoreRemoteChangeNotificationPostOptionKey,
+             NSPersistentHistoryTrackingKey
+            ].forEach { description?.setOption(true as NSNumber, forKey: $0) }
+
             return cloud
         }()
 

--- a/Shared/Persistence/CoreData/CoreDataSessionRepository.swift
+++ b/Shared/Persistence/CoreData/CoreDataSessionRepository.swift
@@ -125,6 +125,8 @@ extension CoreDataSessionRepository: SessionRepository {
                         continue
                     }
                     fileMO.csv = file.csv
+                    guard let device = deviceMOs.first(where: { $0.mac == file.mac }) else { continue }
+                    fileMO.device = device
                 }
                 fileMOs.forEach { sessionMO.addToFiles($0) }
                 return (deviceMOs, context, sessionMO, fileMOs)

--- a/Shared/Persistence/CoreData/DeviceMO+CoreDataClass.swift
+++ b/Shared/Persistence/CoreData/DeviceMO+CoreDataClass.swift
@@ -8,6 +8,7 @@ import CoreData
 public class DeviceMO: NSManagedObject, Identifiable {
     @NSManaged public var mac: String?
     @NSManaged public var session: NSSet?
+    @NSManaged public var files: NSSet?
 }
 
 extension DeviceMO {
@@ -32,5 +33,17 @@ extension DeviceMO {
 
     @objc(removeSession:)
     @NSManaged public func removeFromSession(_ values: NSSet)
+
+    @objc(addFilesObject:)
+    @NSManaged public func addToFiles(_ value: FileMO)
+
+    @objc(removeFilesObject:)
+    @NSManaged public func removeFromFiles(_ value: FileMO)
+
+    @objc(addFiles:)
+    @NSManaged public func addToFiles(_ values: NSSet)
+
+    @objc(removeFiles:)
+    @NSManaged public func removeFromFiles(_ values: NSSet)
 
 }

--- a/Shared/Persistence/CoreData/FileMO+CoreDataClass.swift
+++ b/Shared/Persistence/CoreData/FileMO+CoreDataClass.swift
@@ -10,6 +10,7 @@ public class FileMO: NSManagedObject, Identifiable {
     @NSManaged public var csv: Data?
     @NSManaged public var name: String?
     @NSManaged public var session: SessionMO?
+    @NSManaged public var device: DeviceMO?
 }
 
 extension FileMO {

--- a/Shared/Persistence/CoreData/ModelConvertible.swift
+++ b/Shared/Persistence/CoreData/ModelConvertible.swift
@@ -38,8 +38,8 @@ extension FileMO: ModelConvertible {
               let name = name,
               let csv = csv
         else { throw CocoaError(.coderInvalidValue) }
-
-        return File(id: id, csv: csv, name: name)
+        let mac = device?.mac ?? ""
+        return File(id: id, csv: csv, name: name, mac: mac)
     }
 }
 

--- a/Shared/Persistence/CoreData/Sessions.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Shared/Persistence/CoreData/Sessions.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21E5206e" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="21E5206e" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
     <entity name="DeviceMO" representedClassName="DeviceMO" syncable="YES">
         <attribute name="mac" optional="YES" attributeType="String"/>
+        <relationship name="files" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="FileMO" inverseName="device" inverseEntity="FileMO"/>
         <relationship name="session" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SessionMO" inverseName="devices" inverseEntity="SessionMO"/>
     </entity>
     <entity name="FileMO" representedClassName="FileMO" syncable="YES">
         <attribute name="csv" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String" spotlightIndexingEnabled="YES"/>
+        <relationship name="device" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DeviceMO" inverseName="files" inverseEntity="DeviceMO"/>
         <relationship name="session" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionMO" inverseName="files" inverseEntity="SessionMO"/>
     </entity>
     <entity name="SessionMO" representedClassName="SessionMO" syncable="YES">
@@ -20,8 +22,8 @@
         <relationship name="files" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="FileMO" inverseName="session" inverseEntity="FileMO" spotlightIndexingEnabled="YES"/>
     </entity>
     <elements>
-        <element name="DeviceMO" positionX="-146.4375" positionY="115.11328125" width="128" height="59"/>
-        <element name="FileMO" positionX="-439.72265625" positionY="-0.1796875" width="128" height="89"/>
+        <element name="DeviceMO" positionX="-146.4375" positionY="115.11328125" width="128" height="74"/>
+        <element name="FileMO" positionX="-439.72265625" positionY="-0.1796875" width="128" height="104"/>
         <element name="SessionMO" positionX="-241.44921875" positionY="-129.171875" width="128" height="134"/>
     </elements>
 </model>

--- a/Shared/Persistence/Import/MetaBase4SessionDataImporter.swift
+++ b/Shared/Persistence/Import/MetaBase4SessionDataImporter.swift
@@ -215,7 +215,7 @@ private extension MetaBase4SessionDataImporter {
                     missingFiles.append(path)
                     return
                 }
-                let file = File(id: .init(), csv: data, name: legacyFile.csvFilename)
+                let file = File(id: .init(), csv: data, name: legacyFile.csvFilename, mac: legacy.mac)
                 output.append(file)
             }
         }

--- a/Shared/Root.swift
+++ b/Shared/Root.swift
@@ -88,6 +88,7 @@ public extension Root {
 #if DEBUG
             root = self
             defaults = self.userDefaults
+            sessionsRepo = self.sessions
             printUserDefaults()
 #endif
         } catch { NSLog("Load Failure: \(error.localizedDescription)") }

--- a/Shared/Screens/2_History/VMs/HistoricalSessionsVM.swift
+++ b/Shared/Screens/2_History/VMs/HistoricalSessionsVM.swift
@@ -100,9 +100,10 @@ public extension HistoricalSessionsVM {
         sessionRepo.fetchFiles(sessionID: session.id)
             .receive(on: backgroundQueue)
             .tryMap { files -> FilesExporter in
-                try FilesExporter(
+                let folderName = [session.name, session.date.filenameFormat()].joined(separator: " ")
+                return try FilesExporter(
                     id: session.id,
-                    name: session.name,
+                    name: folderName,
                     files: files
                 )
             }

--- a/Shared/Screens/2_History/VMs/HistoryScreenVM.swift
+++ b/Shared/Screens/2_History/VMs/HistoryScreenVM.swift
@@ -87,7 +87,7 @@ public extension HistoryScreenVM {
                 // No need to reset focus
                 routing.setDestination(.configure)
             case .downloadLog:
-                let ongoingSessionName = logging.session(for: routing.focus!.item)?.name ?? "New Session"
+            let ongoingSessionName = logging.session(for: routing.focus!.item)?.name ?? Session.defaultName
                 routing.setSessionName(ongoingSessionName)
                 routing.setDestination(.downloadLogs)
         }

--- a/Shared/Screens/3_Configure/VMs/ConfigureVM.swift
+++ b/Shared/Screens/3_Configure/VMs/ConfigureVM.swift
@@ -49,7 +49,7 @@ public class ConfigureVM: ObservableObject, HeaderVM {
     // User intent
     @Published private(set) var sessionName: String? = nil
     public var sessionNameBinding: Binding<String> {
-        Binding(get: { [weak self] in self?.sessionName ?? self?.selectedPreset?.name ?? "New Session" },
+        Binding(get: { [weak self] in self?.sessionName ?? self?.selectedPreset?.name ?? Session.defaultName },
                 set: { [weak self] newName in
             guard newName.isEmpty == false
             else { self?.sessionName = nil; return }

--- a/Shared/Screens/4_Action/VMs/ActionVM.swift
+++ b/Shared/Screens/4_Action/VMs/ActionVM.swift
@@ -398,7 +398,8 @@ extension ActionVM: ActionController {
                     csv: .init(),
                     deviceName: deviceName,
                     signal: tables[tableIndex].source,
-                    date: self.startDate
+                    date: self.startDate,
+                    mac: mac
                 )
 
                 // If a prior session was loaded, use this as the starting data

--- a/Shared/Screens/4_Action/VMs/ActionVM.swift
+++ b/Shared/Screens/4_Action/VMs/ActionVM.swift
@@ -452,7 +452,8 @@ internal extension ActionVM {
         }
         self.saveSessionToAppDatabase(didComplete: didComplete)
 
-        do { self.exporter = try .init(id: sessionID, name: title, files: files) }
+        let folderName = [title, startDate.filenameFormat()].joined(separator: " ")
+        do { self.exporter = try .init(id: sessionID, name: folderName, files: files) }
         catch { NSLog("\(Self.self)" + error.localizedDescription) }
 
         DispatchQueue.main.async { [weak self] in

--- a/Shared/UI/Components/EditableSubhead.swift
+++ b/Shared/UI/Components/EditableSubhead.swift
@@ -21,23 +21,20 @@ struct EditableSubhead<T: View>: View {
     let trailing: () -> T
 
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack {
+        HStack(spacing: 15) {
 
-                ResigningTextField(placeholderText: placeholder,
-                                   initialText: label.wrappedValue,
-                                   config: .largeDeviceStyle(),
-                                   onCommit: { label.wrappedValue = $0 })
-                    .padding(.horizontal, 4)
+            ResigningTextField(placeholderText: placeholder,
+                               initialText: label.wrappedValue,
+                               config: .largeDeviceStyle(),
+                               onCommit: { label.wrappedValue = $0 })
+                .padding(.horizontal, 8)
+                .padding(.vertical, 7)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.myGroupBackground2))
 
-                Spacer()
+            Spacer()
 
-                trailing()
-            }
-
-            Divider()
-                .padding(.top, 4)
-                .padding(.bottom, 8)
+            trailing()
         }
+        .padding(.bottom)
     }
 }


### PR DESCRIPTION
Adopts MetaBase 4 file and folder nomenclature, but with one key difference:

- MB4 defines a session per device, even if multiple devices were programmed as a group.
- MB5 defines a session as an umbrella for one or multiple devices that were programmed as a group.

Implication:
- While in MB4 a group of devices is saved as multiple sessions in multiple folders, in MB5 a group of devices is saved in one session object and outputs as one folder.
- The MAC address requested in #4 would be used in the filename, but not the session folder. Will that be an issue?

Folder: SessionName Date (as requested in #4)
Files: HumanName_MAC_LoggerName_Date.csv
